### PR TITLE
Put posts that dont have tags into a default 'Uncategorized' tag

### DIFF
--- a/scrdkd.go
+++ b/scrdkd.go
@@ -305,7 +305,10 @@ func read_post(filename string, conf Configuration) Post {
 			}
 			i = strings.Index(line, ".. tags:")
 			if i != -1 {
-				tagline = line[i+8:]
+				tagline = strings.TrimSpace(line[i+8:])
+				if tagline == "" {
+				  tagline = "Uncategorized"
+				}
 				continue
 			}
 			i = strings.Index(line, ".. author:")


### PR DESCRIPTION
This avoids a bug where one gets a link to '.html', which is invalid
and is forbidden by the web server.