### PR TITLE
Update install.rst

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -4,7 +4,7 @@ Installation
 Install golang
 ---------------
 
-Download golang from `here <https://go.googlecode.com/files/go1.2.1.linux-amd64.tar.gz>`_ , extract go directory
+Download golang from `here <https://golang.org/doc/install?download=go1.8.3.linux-amd64.tar.gz>`_ , extract go directory
 under your home directory.
 
 ::


### PR DESCRIPTION
The download link for golang was broken and is replaced by this new link <https://golang.org/doc/install?download=go1.8.3.linux-amd64.tar.gz>