### PR TITLE
Couple of minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 all:
-	go build -o shonku.bin scrdkd.go posts.go bindata.go
+	GO111MODULE=auto go build -o shonku.bin scrdkd.go posts.go bindata.go
 
 clean:
-	rm .scrdkd.db
+	rm -f .scrdkd.db
 	rm -rf output/*.html
+	rm -f shonku.bin

--- a/scrdkd.go
+++ b/scrdkd.go
@@ -1038,7 +1038,7 @@ func site_rebuild(rebuild, rebuild_index bool) {
 	topath = curpath + "/output/pages/"
 	rsync(frompath, topath)
 	frompath = curpath + "/files/"
-	topath = curpath + "/output/"
+	topath = curpath + "/output/files/"
 	rsync(frompath, topath)
 
 }


### PR DESCRIPTION
I moved things around a bit on my blog today and fixed a couple of issues with shonku, first being better cleaning and `make` working with the new go modules defaults and the second being copying `files` to the right place.